### PR TITLE
Add both libraries to install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,3 +71,5 @@ add_library(OTFCPT_static STATIC ${OTFCPT_SOURCES})
 target_link_libraries(OTFCPT_static ${MPI_C_LIBRARIES})
 
 add_subdirectory(tests)
+
+install(TARGETS OTFCPT OTFCPT_static)


### PR DESCRIPTION
Fix missing `install(...)` directive to have CMake generate `make install` targets.