### PR TITLE
Fix undefined symbol CheckFailed

### DIFF
--- a/parse_flags.cpp
+++ b/parse_flags.cpp
@@ -218,3 +218,11 @@ void NORETURN __otfcpt::Die() {
     abort();
   exit(get_otfcpt_flags()->exitcode);
 }
+
+void NORETURN __otfcpt::CheckFailed(const char *file, int line,
+                                    const char *cond, u64 v1, u64 v2) {
+  fprintf(get_otfcpt_flags()->output,
+          "Check failed in %s:%d %llu %s %llu\n",
+          file, line, v1, cond, v2);
+  Die();
+}


### PR DESCRIPTION
I encountered missing symbol error for the CheckFailed function.

Should we `Die` here?